### PR TITLE
update group config

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       }],
         github: "WebView-CG/usage-and-challenges",
         xref: ["miniapp-packaging"],
-        group: "cg/webview",
+        group: "webview",
       };
     </script>
   </head>

--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
-    "group":      ["cg/webview"]
+    "group":      ["webview"]
 ,   "contacts":   ["dontcallmeDom"]
 ,   "repo-type":  "cg-report"
 }


### PR DESCRIPTION
This should be the correct name from https://respec.org/w3c/groups/ and fix the warning on the HTML page.

![grafik](https://user-images.githubusercontent.com/3585860/213863423-e0233c4a-9131-4190-95e9-dbac44d96f5b.png)
